### PR TITLE
fix: [WebRTC] Perfect Negotiation Pattern fixes

### DIFF
--- a/packages/fe-webrtc/src/model/WebRTCStateDto.ts
+++ b/packages/fe-webrtc/src/model/WebRTCStateDto.ts
@@ -4,6 +4,7 @@ import { Injectables } from './Injectables.js';
 export interface WebRTCStateDto {
   makingOffer: boolean;
   ignoreOffer: boolean;
+  isSettingRemoteAnswerPending: boolean;
   canvasSender: Maybe<RTCRtpSender>;
   remoteVideoChatStreamId: Maybe<string>;
   injectables: Maybe<Injectables>;

--- a/packages/fe-webrtc/src/service/PeerConnectionHandlers.ts
+++ b/packages/fe-webrtc/src/service/PeerConnectionHandlers.ts
@@ -65,12 +65,11 @@ const _handleNegotiationNeeded = async (
 ) => {
   Assert.isDefined(roomId, 'roomId is not defined');
   Assert.isDefined(partnerSocketId, 'partnerId is not defined');
+  Assert.isDefined(socket, 'socket is not defined');
+
   try {
     setState({ makingOffer: true });
-
     await pc.setLocalDescription();
-
-    Assert.isDefined(socket, 'socket is not defined');
     socket.emit(
       'peer-message',
       { description: pc.localDescription },

--- a/packages/fe-webrtc/src/service/SignalingService.ts
+++ b/packages/fe-webrtc/src/service/SignalingService.ts
@@ -20,22 +20,31 @@ const _handleOffer = async (
     return;
   }
 
-  const { makingOffer } = webRTCState.getState();
-  let ignoreOffer = false;
-
   try {
     if (PeerMessage.isDescription(peerMessage) && !!peerMessage.description) {
       const { description } = peerMessage;
-      const offerCollision =
-        description.type === 'offer' &&
-        (makingOffer || peerConnection.signalingState !== 'stable');
+      const { makingOffer, isSettingRemoteAnswerPending } =
+        webRTCState.getState();
 
-      ignoreOffer = !params.observables.isPolite && offerCollision;
+      const readyForOffer =
+        !makingOffer &&
+        (peerConnection.signalingState === 'stable' ||
+          isSettingRemoteAnswerPending);
+
+      const offerCollision = description.type === 'offer' && !readyForOffer;
+
+      const ignoreOffer = !params.observables.isPolite && offerCollision;
       webRTCState.setState({ ignoreOffer });
 
-      if (ignoreOffer) return;
+      if (ignoreOffer) {
+        return;
+      }
 
+      webRTCState.setState({
+        isSettingRemoteAnswerPending: description.type === 'answer',
+      });
       await peerConnection.setRemoteDescription(description); // SRD rolls back as needed
+      webRTCState.setState({ isSettingRemoteAnswerPending: false });
 
       if (description.type === 'offer') {
         await peerConnection.setLocalDescription();
@@ -53,7 +62,10 @@ const _handleOffer = async (
       try {
         await peerConnection.addIceCandidate(peerMessage.candidate);
       } catch (err) {
-        if (!ignoreOffer) throw err; // Suppress ignored offer's candidates
+        const { ignoreOffer } = webRTCState.getState();
+        if (!ignoreOffer) {
+          throw err; // Suppress ignored offer's candidates
+        }
       }
     }
   } catch (error) {

--- a/packages/fe-webrtc/src/service/WebRTCStateService.ts
+++ b/packages/fe-webrtc/src/service/WebRTCStateService.ts
@@ -4,6 +4,7 @@ import type { WebRTCStateHandlers } from '../model/WebRTCStateHandlers.js';
 const initialState: WebRTCStateDto = {
   makingOffer: false,
   ignoreOffer: false,
+  isSettingRemoteAnswerPending: false,
   canvasSender: null,
   remoteVideoChatStreamId: null,
 

--- a/packages/fe-webrtc/src/service/__tests__/WebRTCStateService.test.ts
+++ b/packages/fe-webrtc/src/service/__tests__/WebRTCStateService.test.ts
@@ -9,6 +9,7 @@ describe('WebRTCStateService', () => {
     expect(state.getState()).toEqual({
       makingOffer: false,
       ignoreOffer: false,
+      isSettingRemoteAnswerPending: false,
       canvasSender: null,
       remoteVideoChatStreamId: null,
       injectables: null,
@@ -23,6 +24,7 @@ describe('WebRTCStateService', () => {
     expect(state.getState()).toEqual({
       makingOffer: true,
       ignoreOffer: false,
+      isSettingRemoteAnswerPending: false,
       canvasSender: null,
       remoteVideoChatStreamId: null,
       injectables: null,
@@ -42,10 +44,23 @@ describe('WebRTCStateService', () => {
     expect(state.getState()).toEqual({
       makingOffer: true,
       ignoreOffer: true,
+      isSettingRemoteAnswerPending: false,
       canvasSender: mockSender,
       remoteVideoChatStreamId: null,
       injectables: null,
     });
+  });
+
+  it('should update isSettingRemoteAnswerPending for perfect negotiation', () => {
+    const state = WebRTCStateService.create();
+
+    state.setState({ isSettingRemoteAnswerPending: true });
+
+    expect(state.getState().isSettingRemoteAnswerPending).toBe(true);
+
+    state.setState({ isSettingRemoteAnswerPending: false });
+
+    expect(state.getState().isSettingRemoteAnswerPending).toBe(false);
   });
 
   it('should properly initialize and update injectables', () => {


### PR DESCRIPTION
Implements MDN's Perfect Negotiation pattern to improve WebRTC connection reliability and handle offer collisions correctly.

Changes:
- Added isSettingRemoteAnswerPending state variable to track async answer processing
- Updated collision detection to check both makingOffer and isSettingRemoteAnswerPending
- Fixed ICE candidate suppression to properly read ignoreOffer from state
- Improved readyForOffer calculation following MDN pattern exactly
- Maintained polite/impolite peer roles for collision resolution

The implementation now 100% matches the MDN reference pattern while maintaining type safety and clean separation of concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)